### PR TITLE
Add Ghostty terminal theme

### DIFF
--- a/ghostty.conf
+++ b/ghostty.conf
@@ -1,0 +1,22 @@
+background = #f4f1e8
+foreground = #5c6a53
+cursor-color = #7a9461
+selection-background = #e0d9c8
+selection-foreground = #5c6a53
+
+palette = 0=#e8e2d5
+palette = 1=#c65f5f
+palette = 2=#7a9461
+palette = 3=#d4a574
+palette = 4=#7a92a5
+palette = 5=#a17a8f
+palette = 6=#6fa695
+palette = 7=#8b7355
+palette = 8=#d6ccb9
+palette = 9=#d67b7b
+palette = 10=#8fac70
+palette = 11=#e6bb8a
+palette = 12=#92aec4
+palette = 13=#b892a5
+palette = 14=#82c2ae
+palette = 15=#6b5642


### PR DESCRIPTION
Adds a Ghostty terminal configuration file with matching colors from the theme palette.

Includes:
- Background/foreground from base colors
- Full 16-color terminal palette matching the Alacritty theme
- Cursor and selection colors